### PR TITLE
Fix Chrome

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix message passing and popup size for Chrome
+
 ## [2.1.0] - 2023-10-28
 
 ### Added

--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -3,6 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <link href="./bootstrap.min.css" rel="stylesheet" />
+    <style>
+      body {
+        width: 200px;
+      }
+    </style>
   </head>
 
   <body>


### PR DESCRIPTION
Chrome version is currently broken. This change will:
- Fix message passing for Chrome. Manifest V2 operations in Chrome [only support callbacks](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Chrome_incompatibilities). This change will convert all promise async API calls to using callbacks.
- Set a fixed width for the popup