### PR TITLE
Use local storage for settings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix message passing and popup size for Chrome
+- Persist settings in local storage
 
 ## [2.1.0] - 2023-10-28
 

--- a/src/entrypoints/background.ts
+++ b/src/entrypoints/background.ts
@@ -11,14 +11,16 @@ import { fetchComments } from "../youtube";
 
 const API_KEY = process.env.API_KEY;
 
-let settings: Settings = {
+const DEFAULT_SETTINGS: Settings = {
   commentsVisible: true,
   commentOpacity: OpacityLevel.HIGH,
   commentSpeed: SpeedLevel.HIGH,
 };
 
+let settings: Settings;
+
 /**
- * Syncs settings to all content scripts
+ * Syncs settings to all content scripts and storage
  */
 function syncSettings() {
   const req: SetSettingsRequest = {
@@ -32,31 +34,52 @@ function syncSettings() {
       chrome.tabs.sendMessage(tabs[i].id, req);
     }
   });
+  chrome.storage.local.set({
+    settings: settings,
+  });
 }
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  if (message.id === Message.FETCH_COMMENTS) {
-    (async () => {
-      const req = message as FetchCommentsRequest;
-      const { videoId, pageToken } = req.args;
-      const res = await fetchComments(API_KEY, videoId, pageToken);
+/**
+ * Load settings from local storage
+ */
+async function loadSettings() {
+  const res = (await new Promise((resolve, reject) => {
+    chrome.storage.local.get("settings", (res) => {
+      resolve(res);
+    });
+  })) as any;
+  settings = res.settings
+    ? (res.settings as Settings)
+    : { ...DEFAULT_SETTINGS };
+}
+
+(async () => {
+  await loadSettings();
+
+  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+    if (message.id === Message.FETCH_COMMENTS) {
+      (async () => {
+        const req = message as FetchCommentsRequest;
+        const { videoId, pageToken } = req.args;
+        const res = await fetchComments(API_KEY, videoId, pageToken);
+        sendResponse(res);
+      })();
+      return true;
+    } else if (message.id === Message.GET_SETTINGS) {
+      const res: GetSettingsResponse = {
+        settings,
+      };
       sendResponse(res);
-    })();
-    return true;
-  } else if (message.id === Message.GET_SETTINGS) {
-    const res: GetSettingsResponse = {
-      settings,
-    };
-    sendResponse(res);
-    return true;
-  } else if (message.id === Message.MERGE_SETTINGS) {
-    const req = message as MergeSettingsRequest;
-    settings = { ...settings, ...req.args.settings };
-    syncSettings();
-    const res: MergeSettingsResponse = {
-      settings,
-    };
-    sendResponse(res);
-    return true;
-  }
-});
+      return true;
+    } else if (message.id === Message.MERGE_SETTINGS) {
+      const req = message as MergeSettingsRequest;
+      settings = { ...settings, ...req.args.settings };
+      syncSettings();
+      const res: MergeSettingsResponse = {
+        settings,
+      };
+      sendResponse(res);
+      return true;
+    }
+  });
+})();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -14,7 +14,11 @@
       "48": "icons/logo_48.png"
     }
   },
-  "permissions": ["tabs", "*://*.googleapis.com/youtube/v3/commentThreads/*"],
+  "permissions": [
+    "storage",
+    "tabs",
+    "*://*.googleapis.com/youtube/v3/commentThreads/*"
+  ],
   "background": {
     "scripts": ["background.js"]
   },


### PR DESCRIPTION
### Notes

This change loads settings from local storage. This is so settings persist even when browser is reloaded.


### Testing

`yarn test` is green

Tested in Firefox and Chrome. Loaded extension in debug mode and changed settings. Reloaded extension. Setting persisted.

### Issue

Fixes #5