### PR TITLE
Improve comment animation framerate

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add browser-specific settings id and data collection permissions
+- Add framerate improvements
 
 ## [2.1.3] - 2025-12-16
 

--- a/src/entrypoints/content.ts
+++ b/src/entrypoints/content.ts
@@ -20,6 +20,7 @@ interface CommentView {
   const COMMENT_TEXT_MAX_LENGTH = 200;
   const CANVAS_ID = "niconico-yt-canvas";
   const MAX_NUM_FETCHES = 10;
+  const CANVAS_SCALE = 1;
 
   let numFetchesLeft = MAX_NUM_FETCHES;
   let videoStream: any;
@@ -96,20 +97,23 @@ interface CommentView {
     if (!canvas) {
       canvas = document.createElement("canvas");
       canvas.id = CANVAS_ID;
-      canvas.setAttribute(
-        "style",
-        "width: 100%; position: absolute; pointer-events: none;"
-      );
-      canvas.width = player.clientWidth;
-      canvas.height = player.clientHeight;
+      canvas.style.width = `${player.clientWidth}px`;
+      canvas.style.height = `${player.clientHeight}px`;
+      canvas.style.position = "absolute";
+      canvas.style.pointerEvents = "none";
+      canvas.width = player.clientWidth * CANVAS_SCALE;
+      canvas.height = player.clientHeight * CANVAS_SCALE;
+
       container.appendChild(canvas);
 
       ctx = canvas.getContext("2d");
 
       // Resize canvas
       const resizeObserver = new ResizeObserver((entries) => {
-        ctx.canvas.width = player.clientWidth;
-        ctx.canvas.height = player.clientHeight;
+        ctx.canvas.style.width = `${player.clientWidth}px`;
+        ctx.canvas.style.height = `${player.clientHeight}px`;
+        ctx.canvas.width = player.clientWidth * CANVAS_SCALE;
+        ctx.canvas.height = player.clientHeight * CANVAS_SCALE;
         ctx.fillStyle = "white";
         ctx.lineWidth = 3;
         ctx.lineCap = "round";
@@ -168,7 +172,7 @@ interface CommentView {
     }
   }).observe(document, { subtree: true, childList: true });
 
-  const draw = () => {
+  const draw = (_now: DOMHighResTimeStamp) => {
     requestAnimationFrame(draw);
 
     if (!videoStream || !canvas || !ctx) {
@@ -253,5 +257,5 @@ interface CommentView {
 
   initVideo();
   setInterval(updateComments, 2_000);
-  draw();
+  requestAnimationFrame(draw);
 })();


### PR DESCRIPTION
Improve comment animation framerate. Comments are animating at ~30 FPS due to calculating position directly from the video stream time.

This change improves the framerate by using the animation time to predict where the comment should be when the comment doesn't know where it should be (i.e. when the video stream time does not change on update). This is done by calculating a differential, or deviation, between the animation times from when the comment previously was and where the comment now is and then adding the difference to the current time where the comment currently is. This allows us to calculate where the comment should be from where it was and subsequently move the comment to from where it was to where it now is.

Fixes #9 